### PR TITLE
Removing ENUM field

### DIFF
--- a/db-versions/Version20140330193642.php
+++ b/db-versions/Version20140330193642.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20140330193642 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql", "Migration can only be executed safely on 'mysql'.");
+
+        $this->addSql("ALTER TABLE talk CHANGE complexity complexity VARCHAR(1) DEFAULT 'L' NOT NULL");
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql", "Migration can only be executed safely on 'mysql'.");
+
+        $this->addSql("ALTER TABLE talk CHANGE complexity complexity ENUM('L','M','H') NOT NULL DEFAULT 'L'");
+    }
+}

--- a/src/PHPSC/Conference/Domain/Entity/Talk.php
+++ b/src/PHPSC/Conference/Domain/Entity/Talk.php
@@ -79,7 +79,7 @@ class Talk implements Entity
     private $longDescription;
 
     /**
-     * @Column(type="string", columnDefinition="ENUM('L','M','H') NOT NULL DEFAULT 'L'")
+     * @Column(type="string", length=1, options={"default":"L"})
      * @var string
      */
     private $complexity;


### PR DESCRIPTION
Esse PR altera a entidade e adiciona uma versão do DB, fazendo com que o atributo `complexity` seja mapeado como varchar ao invés de ENUM.
