### PR TITLE
Consistent time on schedule for talks.

### DIFF
--- a/public/js/talks/schedule.js
+++ b/public/js/talks/schedule.js
@@ -192,12 +192,12 @@ function createBody(items)
 
 function getItemTime(timeString)
 {
-    var time = (new Date(timeString)).toLocaleTimeString();
+    var time = (new Date(timeString));
     
-    time = time.replace(/\u200E/g, '');
-    time = time.replace(/^([^\d]*\d{1,2}:\d{1,2}):\d{1,2}([^\d]*)$/, '$1$2');
+    hours = time.getHours();
+    minutes = time.getMinutes();
     
-    return time;
+    return hours+":"+minutes;
 }
 
 function getItemsColumns(current, items)


### PR DESCRIPTION
Instead of relying into the [Date.toLocaleDateString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) which is **very**
browser dependent, get Hour and Minute information directly using
Date.getHours() and Date.getMinutes() methods.

PS: I haven't tested this. :stuck_out_tongue: 
